### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ eventually. This can be done by modifying the SSH config file at
 change, but I have noticed that fail2ban does not seem to enjoy being
 modified after the fact. If this is the case for you just modify the
 iptables manually. To delete the original rule, find its number with
-`iptables -L --v --n --line-numbers` and deleting it with `iptables --D
+`iptables -L -v -n --line-numbers` and deleting it with `iptables --D
 INPUT #`. Now to add your bespoke SSH port with fail2ban issue the
 following command `iptables -A INPUT -p tcp --dport SSHPORT# -j
 f2b-sshd`.


### PR DESCRIPTION
On line 80, the original iptables command was: 
iptables -L --v --n --line-numbers

I have proposed a change to: 
iptables -L -v -n --line-numbers 

This is the correct formatting.

System: Ubuntu 18.04, iptables v.1.6.1